### PR TITLE
Dev -> main

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Exclude VCS
+.git
+.gitignore
+
+# OS / editor junk
+.DS_Store
+*.swp
+*.swo
+*~
+
+# Local config and runtime data (mounted at runtime; never needed in build context)
+config/
+dashboard-data/
+
+# Backups and dumps
+config/WGDashboard_Backup/
+*.tar
+*.tar.gz
+*.zip
+*.log
+
+# Docker
+Dockerfile.*
+.env

--- a/.github/workflows/debug-workflow.yml
+++ b/.github/workflows/debug-workflow.yml
@@ -2,13 +2,21 @@
 name: Debug GitHub Actions
 
 on:
-  workflow_dispatch: {}  # Manual trigger
+  workflow_dispatch: {} # Manual trigger
 
-permissions: write-all
+permissions:
+  contents: read
+  actions: read
+  packages: read
 
 jobs:
   debug-permissions:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      packages: read
+      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -27,9 +35,8 @@ jobs:
                -H "Accept: application/vnd.github.v3+json" \
                https://api.github.com/rate_limit
 
-          echo "Can write to contents? ${{ contains(github.token_permissions.contents, 'write') }}"
-          echo "Can write to packages? ${{ contains(github.token_permissions.packages, 'write') }}"
-          echo "Can write to security_events? ${{ contains(github.token_permissions.security_events, 'write') }}"
+          # Note: GitHub does not expose token permissions as a context here.
+          # To verify permissions, rely on job/workflow-level 'permissions' or attempt scoped API calls.
 
       - name: Check DockerHub Credentials
         run: |
@@ -46,12 +53,15 @@ jobs:
           fi
 
       - name: Check workflow execution status
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           REPO_OWNER=$(echo "${{ github.repository }}" | cut -d '/' -f 1)
           REPO_NAME=$(echo "${{ github.repository }}" | cut -d '/' -f 2)
 
           # Get workflow runs
-          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          sudo apt-get update -y && sudo apt-get install -y jq >/dev/null 2>&1
+          curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
                -H "Accept: application/vnd.github.v3+json" \
                "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/actions/runs?per_page=10" | \
           jq '.workflow_runs[] | {id: .id, name: .name, status: .status, conclusion: .conclusion, created_at: .created_at}'
@@ -78,13 +88,13 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: test-sarif.json
-          category: 'test'
+          category: "test"
 
   test-github-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: false  # Set to true only for testing
+    if: false # Set to true only for testing
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -99,7 +109,7 @@ jobs:
 
   test-docker-hub:
     runs-on: ubuntu-latest
-    if: false  # Set to true only for testing
+    if: false # Set to true only for testing
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,17 +4,17 @@ name: Build and Publish Docker Image
 on:
   push:
     branches: [main, dev]
-    tags: ['v*']
+    tags: ["v*"]
   pull_request:
     branches: [main]
   workflow_dispatch: {}
   schedule:
-    - cron: '0 2 * * 0'  # Weekly on Sundays at 2:00 AM
+    - cron: "0 2 * * 0" # Weekly on Sundays at 2:00 AM
 
-permissions: write-all  # Grant all permissions to ensure nothing is blocked
+permissions: write-all # Grant all permissions to ensure nothing is blocked
 
 env:
-  ACTIONS_RUNNER_DEBUG: true  # Enable debug mode for Actions
+  ACTIONS_RUNNER_DEBUG: true # Enable debug mode for Actions
 
 jobs:
   test:
@@ -54,15 +54,15 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: test-image:latest
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: 'trivy-results.sarif'
-          category: 'trivy'
+          sarif_file: "trivy-results.sarif"
+          category: "trivy"
 
   docker:
     runs-on: ubuntu-latest
@@ -83,7 +83,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
-          platforms: 'arm64,arm'
+          platforms: "arm64,arm"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -102,6 +102,8 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=beta,enable=${{ github.ref == format('refs/heads/{0}', 'dev') }}
+            type=semver,pattern=v{{version}}
+            type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,15 @@ Thumbs.db
 .vscode/
 *.swp
 *.swo
+
+# Never commit WireGuard secrets or configs
+config/privatekey
+config/publickey
+config/wg0.conf
+config/WGDashboard_Backup/
+
+# Archives and logs
+*.tar
+*.tar.gz
+*.zip
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,32 @@
 FROM alpine:latest
 
-# Install dependencies and Wireguard
-RUN apk update && \
-  apk add --no-cache \
-  wireguard-tools \
-  python3 \
-  python3-dev \
-  git \
-  iptables \
-  net-tools \
-  gcc \
-  musl-dev \
-  linux-headers \
-  sudo \
-  openrc \
+# Install runtime dependencies and temporary build deps
+RUN apk update && apk add --no-cache \
+    wireguard-tools \
+    python3 \
+    py3-pip \
+    git \
+    iptables \
+    net-tools \
   bash \
-  curl
+    curl \
+    ca-certificates \
+  sudo \
+  && apk add --no-cache --virtual .build-deps \
+    python3-dev \
+    gcc \
+    musl-dev \
+    linux-headers
 
-# Install WGDashboard
-RUN git clone https://github.com/donaldzou/WGDashboard.git /opt/WGDashboard && \
+# Install WGDashboard (shallow clone) and Python deps
+ENV PIP_NO_CACHE_DIR=1
+RUN git clone --depth 1 https://github.com/donaldzou/WGDashboard.git /opt/WGDashboard && \
   cd /opt/WGDashboard/src && \
   chmod +x ./wgd.sh && \
-  ./wgd.sh install
+  ./wgd.sh install && \
+  (update-ca-certificates || true) && \
+  apk del .build-deps && \
+  rm -rf /var/cache/apk/* /root/.cache
 
 # Create necessary directories
 RUN mkdir -p /etc/wireguard
@@ -35,6 +40,9 @@ RUN chmod +x /entrypoint.sh
 
 # Expose ports for WireGuard and WGDashboard
 EXPOSE 51820/udp 10086/tcp
+
+# Lightweight healthcheck: verify dashboard port responds (uses env var if overridden)
+HEALTHCHECK --interval=30s --timeout=5s --retries=5 CMD sh -c 'curl -fsS "http://127.0.0.1:${WG_DASHBOARD_PORT:-10086}/" >/dev/null || exit 1'
 
 # Start services
 ENTRYPOINT ["/entrypoint.sh"] 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ A Docker image running Wireguard VPN server with WGDashboard web interface on Al
 
 ## Supported Tags
 
-- `latest` - Latest stable release from the main branch
-- `stable` - Stable release, tagged with version
-- `beta` - Development build from the dev branch
-- `x.y.z` - Specific version releases (e.g., `1.0.0`, `1.2.3`)
-- `linux/amd64`, `linux/arm64`, `linux/arm/v7`, `linux/arm/v6` - Platform-specific images
+- `latest` - Auto-applied on pushes to `main`
+- `stable` - Published on version tags (also applied on `main` builds for convenience)
+- `beta` - Auto-applied on pushes to `dev`
+- `vX.Y.Z` and `X.Y.Z` - Versioned releases (semantic versioning)
+- Multi-arch support: `linux/amd64`, `linux/arm64`, `linux/arm/v7`, `linux/arm/v6`
 
 ## Quick Start
 
@@ -58,8 +58,6 @@ docker run -d \
 1. Create a `docker-compose.yml` file:
 
 ```yaml
-version: '3'
-
 services:
   wireguard:
     image: j4v3l/wireguard-dashboard:beta
@@ -91,6 +89,12 @@ services:
     sysctls:
       - net.ipv4.ip_forward=1
       - net.ipv6.conf.all.forwarding=1 
+    # Optional: pin the embedded WGDashboard version (tag/branch/commit)
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        WGDASHBOARD_REF: master
 ```
 
 1. Start the container:
@@ -272,6 +276,18 @@ docker-compose up -d
 # With Docker Compose
 docker-compose pull
 docker-compose up -d
+```
+
+### Release and Tagging
+
+- Push a git tag like `v1.2.3` to trigger a multi-arch build and publish versioned images:
+  - Docker Hub: `j4v3l/wireguard-dashboard:v1.2.3`, plus `stable`
+  - GHCR: `ghcr.io/j4v3l/wireguard-dashboard:v1.2.3`, plus `stable`
+- Merges to `main` publish `latest` (and `stable` as an alias), merges to `dev` publish `beta`.
+- To pin a specific WGDashboard version baked into the image, build with:
+
+```bash
+docker build --build-arg WGDASHBOARD_REF=v4.2.3 -t j4v3l/wireguard-dashboard:v4.2.3 .
 ```
 
 ### Backup

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ services:
       - net.ipv6.conf.all.forwarding=1 
 ```
 
-2. Start the container:
+1. Start the container:
 
 ```bash
 docker-compose up -d
@@ -103,7 +103,7 @@ docker-compose up -d
 
 Once the container is running, access the WGDashboard at:
 
-```
+```text
 http://your-server-ip:10086
 ```
 
@@ -127,8 +127,11 @@ Default login credentials:
 | `WG_DASHBOARD_HOST` | `0.0.0.0` | WGDashboard interface binding address |
 | `WG_ALLOWED_IPS` | `0.0.0.0/0, ::/0` | IPs/networks to route through the VPN for clients |
 | `WG_PERSISTENT_KEEPALIVE` | `25` | KeepAlive interval in seconds for NAT traversal |
+| `WG_MTU` | `1420` | MTU for the WireGuard interface. Tuning this can improve throughput on some networks |
+| `WG_DNS_SERVERS` | `1.1.1.1,8.8.8.8` | Comma-separated DNS servers to use in client configs |
 | `AUTO_UPDATE` | `false` | Enable automatic updates of wireguard-tools. Set to `true` to enable |
 | `UPDATE_DASHBOARD` | `false` | Enable automatic updates of WGDashboard. Set to `true` to enable |
+| `DEBUG` | `false` | Enable verbose logging and additional diagnostics |
 
 ## Automatic Updates
 
@@ -246,6 +249,14 @@ To view container logs:
 docker logs wireguard
 # or with docker-compose
 docker-compose logs wireguard
+```
+
+### Healthcheck
+
+This image includes a Docker healthcheck that probes the WGDashboard on port 10086. In Docker Compose, you can see the health status with:
+
+```bash
+docker ps --format '{{.Names}}\t{{.Status}}'
 ```
 
 ## Updates and Maintenance

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,11 @@
-version: '3'
-
 services:
   wireguard:
-    image: j4v3l/wireguard-dashboard:beta
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        WGDASHBOARD_REF: master
+    image: wireguard-dashboard:local
     container_name: wireguard
     cap_add:
       - NET_ADMIN
@@ -11,17 +14,17 @@ services:
       - TZ=${TZ:-UTC}
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
-      - WG_HOST=${WG_HOST:-auto}  # Server's public IP, 'auto' for automatic detection
-      - WG_PORT=${WG_PORT:-51820}  # WireGuard port
-      - WG_DASHBOARD_PORT=${WG_DASHBOARD_PORT:-10086}  # WGDashboard web interface port
-      - WG_DASHBOARD_HOST=${WG_DASHBOARD_HOST:-0.0.0.0}  # WGDashboard bind address
-      - WG_ALLOWED_IPS=${WG_ALLOWED_IPS:-0.0.0.0/0, ::/0}  # Allowed IPs for clients
-      - WG_PERSISTENT_KEEPALIVE=${WG_PERSISTENT_KEEPALIVE:-25}  # KeepAlive interval
-      - WG_DNS_SERVERS=${WG_DNS_SERVERS:-1.1.1.1,8.8.8.8}  # DNS servers for clients
-      - WG_MTU=${WG_MTU:-1420}  # MTU size for the VPN connection
-      - DEBUG=${DEBUG:-false}  # Enable debug logging
-      - AUTO_UPDATE=${AUTO_UPDATE:-false}  # Enable automatic updates of packages
-      - UPDATE_DASHBOARD=${UPDATE_DASHBOARD:-false}  # Enable automatic updates of WGDashboard
+      - WG_HOST=${WG_HOST:-auto} # Server's public IP, 'auto' for automatic detection
+      - WG_PORT=${WG_PORT:-51820} # WireGuard port
+      - WG_DASHBOARD_PORT=${WG_DASHBOARD_PORT:-10086} # WGDashboard web interface port
+      - WG_DASHBOARD_HOST=${WG_DASHBOARD_HOST:-0.0.0.0} # WGDashboard bind address
+      - WG_ALLOWED_IPS=${WG_ALLOWED_IPS:-0.0.0.0/0, ::/0} # Allowed IPs for clients
+      - WG_PERSISTENT_KEEPALIVE=${WG_PERSISTENT_KEEPALIVE:-25} # KeepAlive interval
+      - WG_DNS_SERVERS=${WG_DNS_SERVERS:-1.1.1.1,8.8.8.8} # DNS servers for clients
+      - WG_MTU=${WG_MTU:-1420} # MTU size for the VPN connection
+      - DEBUG=${DEBUG:-false} # Enable debug logging
+      - AUTO_UPDATE=${AUTO_UPDATE:-false} # Enable automatic updates of packages
+      - UPDATE_DASHBOARD=${UPDATE_DASHBOARD:-false} # Enable automatic updates of WGDashboard
     volumes:
       - ./config:/etc/wireguard
       - ./dashboard-data:/opt/WGDashboard/src/db
@@ -29,7 +32,15 @@ services:
       - "${WG_PORT:-51820}:51820/udp"
       - "${WG_DASHBOARD_PORT:-10086}:10086/tcp"
     restart: unless-stopped
-    privileged: true  # Required for wireguard kernel module and network changes
+    privileged: true # Required for wireguard kernel module and network changes
     sysctls:
       - net.ipv4.ip_forward=1
-      - net.ipv6.conf.all.forwarding=1 
+      - net.ipv6.conf.all.forwarding=1
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:10086/"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,8 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        WGDASHBOARD_REF: master
+        # Allows pinning WGDashboard to a tag/branch/commit; override via env WGDASHBOARD_REF
+        WGDASHBOARD_REF: "${WGDASHBOARD_REF:-main}"
     image: wireguard-dashboard:local
     container_name: wireguard
     cap_add:
@@ -44,3 +45,7 @@ services:
     dns:
       - 1.1.1.1
       - 8.8.8.8
+
+    labels:
+      - "org.opencontainers.image.title=wireguard-dashboard"
+      - "org.opencontainers.image.version=${IMAGE_VERSION:-dev}"

--- a/env.example
+++ b/env.example
@@ -22,5 +22,8 @@ DEBUG=false                # Enable verbose debugging logs
 AUTO_UPDATE=false          # Set to true to enable automatic updates of Wireguard tools
 UPDATE_DASHBOARD=false     # Set to true to enable automatic updates of WGDashboard
 
-# Docker image to use (leave empty for local build)
-# DOCKER_IMAGE=username/wireguard-dashboard:latest 
+# Docker image to use (leave empty for local build) or override in compose
+# DOCKER_IMAGE=j4v3l/wireguard-dashboard:latest
+
+# Build-time: Pin WGDashboard version baked into the image (tag/branch/commit)
+# WGDASHBOARD_REF=master

--- a/env.example
+++ b/env.example
@@ -10,10 +10,13 @@ WG_HOST=auto               # Server's public IP, 'auto' for automatic detection
 WG_PORT=51820              # WireGuard port
 WG_ALLOWED_IPS=0.0.0.0/0, ::/0  # Allowed IPs for clients
 WG_PERSISTENT_KEEPALIVE=25 # KeepAlive interval in seconds
+WG_MTU=1420                # MTU for WireGuard interface (tune for your network)
+WG_DNS_SERVERS=1.1.1.1,8.8.8.8  # Comma-separated DNS servers pushed to clients
 
 # WGDashboard settings
 WG_DASHBOARD_PORT=10086    # WGDashboard web interface port
 WG_DASHBOARD_HOST=0.0.0.0  # WGDashboard bind address
+DEBUG=false                # Enable verbose debugging logs
 
 # Automatic updates
 AUTO_UPDATE=false          # Set to true to enable automatic updates of Wireguard tools


### PR DESCRIPTION
# 🚀 Pull Request

Thank you for your contribution! Please fill out this PR template to help us review your changes.

## 📋 Summary

WGDashboard v4.3.0 enablement and release pipeline hardening.

This PR delivers a thorough audit and a set of improvements across the image, entrypoint, CI, and docs to make builds reproducible, tagging predictable, tests reliable, and the dashboard version easily pinnable:

- Add build-time pinning for WGDashboard via `ARG WGDASHBOARD_REF` (default `main`); example: `WGDASHBOARD_REF=v4.3.0`
- Harden Dockerfile checkout logic for tag/branch/commit and keep shallow clone
- Fix CI test run failures: avoid read-only sysctl writes in CI/TEST mode; default `WG_MTU` to avoid "unbound variable"
- Healthcheck for WGDashboard (Dockerfile and Compose)
- Tagging policy: `latest` on `main`, `beta` on `dev`, `stable` on `main` and `v*` tags, and publish both `vX.Y.Z` and `X.Y`
- Least-privilege debug workflow (remove `write-all`, add required scoped permissions; install `jq` before use)
- Compose: pass `WGDASHBOARD_REF` to builds, add lightweight metadata labels
- Documentation: updated README (supported tags, release flow, build arg), `env.example` (new knobs)
- Hygiene: `.dockerignore` and `.gitignore` tuned to reduce context and protect secrets
- Networking reliability: CA certificates present; DNS defaults documented; dashboard update-check works in container

## 🛠️ Type of Change

- [x] Bug fix 🐞 (CI/test container startup issues; update-check reliability)
- [x] New feature ✨ (pin WGDashboard version via build arg; consistent tag publishing)
- [x] Documentation update 📚 (README, env.example)
- [x] Refactor 🔨 (entrypoint hardening, Dockerfile/Compose/Workflows)
- [ ] Other (please describe):

## 🔗 Related Issue(s)

- Resolves CI test failures due to read-only `/proc` sysctls and unbound `WG_MTU` in test mode
- Improves dashboard update-check reliability (TLS/DNS/CA in image)
  

## 📸 Screenshots / Configs (if applicable)

Tag publishing (excerpt from workflow):

```yaml
tags: |
  type=semver,pattern={{version}}
  type=semver,pattern={{major}}.{{minor}}
  type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
  type=raw,value=beta,enable=${{ github.ref == 'refs/heads/dev' }}
  type=semver,pattern=v{{version}}
  type=raw,value=stable,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
```

Pinning the embedded WGDashboard (Compose build):

```yaml
services:
  wireguard:
    build:
      context: .
      dockerfile: Dockerfile
      args:
        WGDASHBOARD_REF: "${WGDASHBOARD_REF:-main}"  # e.g. v4.3.0
```

## ✅ Checklist

- [x] I have tested my changes locally (build + run with TEST_MODE=true)
- [x] I have updated documentation if needed (README, env.example)
- [x] I have added relevant tests (if applicable)
- [x] I have checked that my code follows the code style
- [x] I have searched for existing PRs for this change

---

🙏 Thank you for your contribution to Wireguard Dashboard Docker! 🎉
